### PR TITLE
Merge branch backlight into lnls_zoom

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -21,6 +21,10 @@ class EPICSActuator(AbstractActuator):
     def init(self):
         self.update_state(self.STATES.READY)
         self.connect(self.get_channel_object("rbv"), "update", self.update_value)
+        low_limit = self.get_property("low_limit")
+        high_limit = self.get_property("high_limit")
+        if (low_limit is not None) and (high_limit is not None):
+            self._nominal_limits = (low_limit, high_limit)
 
     def hasnt_arrived(self, setpoint):
         readback = self.get_value()

--- a/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
+++ b/mxcubecore/HardwareObjects/LNLS/EPICS/EPICSActuator.py
@@ -23,8 +23,11 @@ class EPICSActuator(AbstractActuator):
         self.connect(self.get_channel_object("rbv"), "update", self.update_value)
         low_limit = self.get_property("low_limit")
         high_limit = self.get_property("high_limit")
+        tolerance = self.get_property("tolerance")
         if (low_limit is not None) and (high_limit is not None):
             self._nominal_limits = (low_limit, high_limit)
+        if (tolerance is not None):
+            self.unit = tolerance
 
     def hasnt_arrived(self, setpoint):
         readback = self.get_value()


### PR DESCRIPTION
Allow low_limit and high_limit to be defined at configuration file. Default value is used if any of them was not defined. This is the case e.g. for all EPICSMotors, which inhetir from the EPICSActuator class.