### PR TITLE
Implement LNLSResolution

### DIFF
--- a/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
@@ -59,7 +59,9 @@ class ResolutionVirtualMotor(EPICSMotor):
         self.dx = self.n_pixels_x * self.pixel_size_mm
         self.dy = self.n_pixels_y * self.pixel_size_mm
         super().init()
-        self.connect(self.get_channel_object("wavelength_rbv"), "update", self.update_value)
+        self.connect(
+            self.get_channel_object("wavelength_rbv"), "update", self.update_value
+        )
 
     def get_limits(self):
         llm, hlm = super().get_limits()

--- a/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
@@ -56,8 +56,7 @@ class ResolutionVirtualMotor(EPICSMotor):
         super().init()
 
     def get_limits(self):
-        llm = self.get_channel_value(self.MOTOR_LLM)
-        hlm = self.get_channel_value(self.MOTOR_HLM)
+        llm, hlm = super().get_limits()
         low_limit = self.distance_to_resolution(llm)
         high_limit = self.distance_to_resolution(hlm)
         return (low_limit, high_limit)

--- a/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
@@ -25,19 +25,24 @@ class ResolutionVirtualMotor(EPICSMotor):
         "":
     "MX2:cam1:BeamX":
         channels:
-        beam_x:
-            suffix: ""
-            polling_period: 200
+            beam_x:
+                suffix: ""
+                polling_period: 200
     "MX2:cam1:BeamY":
         channels:
-        beam_y:
-            suffix: ""
-            polling_period: 200
+            beam_y:
+                suffix: ""
+                polling_period: 200
+    "MX2:cam1:Wavelength":
+        channels:
+            wavelength_rbv:
+                suffix: ""
+                polling_period: 200
     configuration:
-    tolerance: 0.01
-    pixel_size_mm: 0.172
-    n_pixels_x: 1475
-    n_pixels_y: 1679
+        tolerance: 0.01
+        pixel_size_mm: 0.172
+        n_pixels_x: 1475
+        n_pixels_y: 1679
     """
 
     BEAM_X_RBV = "beam_x"
@@ -54,6 +59,7 @@ class ResolutionVirtualMotor(EPICSMotor):
         self.dx = self.n_pixels_x * self.pixel_size_mm
         self.dy = self.n_pixels_y * self.pixel_size_mm
         super().init()
+        self.connect(self.get_channel_object("wavelength_rbv"), "update", self.update_value)
 
     def get_limits(self):
         llm, hlm = super().get_limits()

--- a/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
@@ -1,0 +1,109 @@
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSMotor import EPICSMotor
+from mxcubecore import HardwareRepository as HWR
+import logging
+from math import (
+    asin,
+    atan,
+    sin,
+    tan,
+)
+
+
+class ResolutionVirtualMotor(EPICSMotor):
+    """
+    This class implements the resolution virtual motor.
+
+    YAML Example
+    ------------
+
+    %YAML 1.2
+    ---
+    class: LNLS.LNLSResolution.ResolutionVirtualMotor
+    epics:
+    "MNC:B:PB04:CS1:m9":
+        channels:
+        "":
+    "MX2:cam1:BeamX":
+        channels:
+        beam_x:
+            suffix: ""
+            polling_period: 200
+    "MX2:cam1:BeamY":
+        channels:
+        beam_y:
+            suffix: ""
+            polling_period: 200
+    configuration:
+    tolerance: 0.01
+    pixel_size_mm: 0.172
+    n_pixels_x: 1475
+    n_pixels_y: 1679
+    """
+    BEAM_X_RBV = "beam_x"
+    BEAM_Y_RBV = "beam_y"
+
+    def __init__(self,  name: str):
+        super().__init__(name)
+        self.wavelength = HWR.beamline.get_object_by_role("wavelength")
+
+    def init(self):
+        self.pixel_size_mm = self.get_property("pixel_size_mm")
+        self.n_pixels_x = self.get_property("n_pixels_x")
+        self.n_pixels_y = self.get_property("n_pixels_y")
+        self.dx = self.n_pixels_x  * self.pixel_size_mm
+        self.dy = self.n_pixels_y  * self.pixel_size_mm
+        super().init()
+
+    def get_limits(self):
+        llm = self.get_channel_value(self.MOTOR_LLM)
+        hlm = self.get_channel_value(self.MOTOR_HLM)
+        low_limit = self.distance_to_resolution(llm)
+        high_limit = self.distance_to_resolution(hlm)
+        return (low_limit, high_limit)
+
+    def get_radius(self):
+        distance = self.get_channel_value("rbv")
+        beam_x = self.get_channel_value(self.BEAM_X_RBV) * self.pixel_size_mm
+        radius_x = min(beam_x, self.dx - beam_x)
+        beam_y = self.get_channel_value(self.BEAM_Y_RBV) * self.pixel_size_mm
+        radius_y = min(beam_y, self.dy - beam_y)
+        return min(radius_x, radius_y)
+
+    def distance_to_resolution(self, distance):
+        wavelength = self.wavelength.get_value()
+        radius = self.get_radius()
+        try:
+            two_theta = atan(radius / distance)
+            theta = two_theta / 2
+            return wavelength / (2 * sin(theta))
+        except Exception as e:
+            msg = f"Error converting distance to resolution: {e}"
+            self.print_log(level="error", msg=msg)
+            return None
+
+    def resolution_to_distance(self, resolution):
+        wavelength = self.wavelength.get_value()
+        radius = self.get_radius()
+        try:
+            theta = asin(wavelength / (2 * resolution))
+            two_theta = 2 * theta
+            distance = radius / tan(two_theta)
+            return distance
+        except Exception as e:
+            msg = f"Error converting resolution to distance: {e}"
+            self.print_log(level="error", msg=msg)
+            return None
+
+    def get_value(self):
+        distance = super().get_value()
+        return self.distance_to_resolution(distance)
+
+    def update_value(self, value=None) -> None:
+        value = self.get_value()
+        super().update_value(value)
+
+    def _set_value(self, value):
+        resolution = value
+        distance = self.resolution_to_distance(resolution)
+        if distance is not None:
+            super()._set_value(distance)

--- a/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
+++ b/mxcubecore/HardwareObjects/LNLS/LNLSResolution.py
@@ -1,12 +1,12 @@
-from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSMotor import EPICSMotor
-from mxcubecore import HardwareRepository as HWR
-import logging
 from math import (
     asin,
     atan,
     sin,
     tan,
 )
+
+from mxcubecore import HardwareRepository as HWR
+from mxcubecore.HardwareObjects.LNLS.EPICS.EPICSMotor import EPICSMotor
 
 
 class ResolutionVirtualMotor(EPICSMotor):
@@ -39,10 +39,11 @@ class ResolutionVirtualMotor(EPICSMotor):
     n_pixels_x: 1475
     n_pixels_y: 1679
     """
+
     BEAM_X_RBV = "beam_x"
     BEAM_Y_RBV = "beam_y"
 
-    def __init__(self,  name: str):
+    def __init__(self, name: str):
         super().__init__(name)
         self.wavelength = HWR.beamline.get_object_by_role("wavelength")
 
@@ -50,8 +51,8 @@ class ResolutionVirtualMotor(EPICSMotor):
         self.pixel_size_mm = self.get_property("pixel_size_mm")
         self.n_pixels_x = self.get_property("n_pixels_x")
         self.n_pixels_y = self.get_property("n_pixels_y")
-        self.dx = self.n_pixels_x  * self.pixel_size_mm
-        self.dy = self.n_pixels_y  * self.pixel_size_mm
+        self.dx = self.n_pixels_x * self.pixel_size_mm
+        self.dy = self.n_pixels_y * self.pixel_size_mm
         super().init()
 
     def get_limits(self):
@@ -62,7 +63,6 @@ class ResolutionVirtualMotor(EPICSMotor):
         return (low_limit, high_limit)
 
     def get_radius(self):
-        distance = self.get_channel_value("rbv")
         beam_x = self.get_channel_value(self.BEAM_X_RBV) * self.pixel_size_mm
         radius_x = min(beam_x, self.dx - beam_x)
         beam_y = self.get_channel_value(self.BEAM_Y_RBV) * self.pixel_size_mm
@@ -76,9 +76,11 @@ class ResolutionVirtualMotor(EPICSMotor):
             two_theta = atan(radius / distance)
             theta = two_theta / 2
             return wavelength / (2 * sin(theta))
-        except Exception as e:
-            msg = f"Error converting distance to resolution: {e}"
-            self.print_log(level="error", msg=msg)
+        except ZeroDivisionError:
+            self.print_log(level="error", msg="Distance cannot be zero")
+            return None
+        except TypeError as e:
+            self.print_log(level="error", msg=f"Invalid numeric input: {e}")
             return None
 
     def resolution_to_distance(self, resolution):
@@ -87,11 +89,12 @@ class ResolutionVirtualMotor(EPICSMotor):
         try:
             theta = asin(wavelength / (2 * resolution))
             two_theta = 2 * theta
-            distance = radius / tan(two_theta)
-            return distance
-        except Exception as e:
-            msg = f"Error converting resolution to distance: {e}"
-            self.print_log(level="error", msg=msg)
+            return radius / tan(two_theta)
+        except ZeroDivisionError:
+            self.print_log(level="error", msg="Resolution cannot be zero")
+            return None
+        except TypeError as e:
+            self.print_log(level="error", msg=f"Invalid numeric input: {e}")
             return None
 
     def get_value(self):


### PR DESCRIPTION
We are finishing the implementation of the UI components, and we understood that the resolution will need a specific class for itself instead of using `AbstractResolution`. The reasons are:

- Our energy component is an `EPICSActuatorBluesky` component and does not have a `get_wavelength` attribute
- We don't have a `_hwr_detector.distance` component: we use `EPICSMotor` and a configuration file.
- Instead of having `_hwr_detector`, we just need to add pixel_size_mm,  n_pixels_x and n_pixels_y to the yaml file of `ResolutionVirtualMotor`, and that is sufficient for calculating the resolution. Our beam center has its own EPICS PVs, that are also passed in the yaml file. MXCuBE doesn't need to know extra information about the detector because our data collection will be handled by bluesky plans.